### PR TITLE
Ruby 1.9.3 Support

### DIFF
--- a/ext/texplay/bindings.c
+++ b/ext/texplay/bindings.c
@@ -308,7 +308,7 @@ m_clone_image(VALUE self)
 
     cloned_image = m_dup_image(self);
 
-    #if RUBY_API_VERSION_MAJOR >=2 && RUBY_API_VERSION_MINOR >= 1
+    #if RUBY_API_VERSION_MAJOR <= 1 || (RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR == 0)
         /* the main diff b/w clone and dup is that clone also dups the singleton */
         rb_obj_reveal(cloned_image, rb_singleton_class_clone(self));
     #else

--- a/ext/texplay/compat.h
+++ b/ext/texplay/compat.h
@@ -19,7 +19,7 @@
 # define RCLASS_IV_TBL(c) (RCLASS(c)->iv_tbl)
 #endif
 
-#if RUBY_API_VERSION_MAJOR <= 2 && RUBY_API_VERSION_MINOR < 1
+#if RUBY_API_VERSION_MAJOR <= 1 || (RUBY_API_VERSION_MAJOR == 2 && RUBY_API_VERSION_MINOR == 0)
 #define KLASS_OF(c) (RBASIC(c)->klass)
 #endif
 


### PR DESCRIPTION
Reference: #26 or https://github.com/banister/texplay/issues/26

Ruby 1.9.3 does not support `rb_obj_reveal` so ifdef conditionals were added to allow the gem to be compiled.
